### PR TITLE
readme: add deepdive row

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 | Project | What it does | |
 |---------|-------------|---|
 | **[dario](https://github.com/askalf/dario)** | A universal LLM router. One local endpoint, every provider — OpenAI, Groq, OpenRouter, Ollama, Claude subscriptions, any OpenAI-compat URL. Your tools point here and stop caring which vendor is upstream. | [![npm](https://img.shields.io/npm/v/@askalf/dario?label=&color=00ff88&style=flat-square)](https://www.npmjs.com/package/@askalf/dario) |
+| **[deepdive](https://github.com/askalf/deepdive)** | A local research agent. One command, cited answer — plan, search, read, iterate with a critic loop, synthesize. Routes LLM calls through dario so deep research runs on your own subscription. | [![npm](https://img.shields.io/npm/v/@askalf/deepdive?label=&color=00ff88&style=flat-square)](https://www.npmjs.com/package/@askalf/deepdive) |
 
 ---
 


### PR DESCRIPTION
Adds a deepdive row to the main askalf/askalf README's project table, right after dario.

Matches the current Local-first LLM infrastructure positioning — leads with what deepdive is (a local research agent), summarizes the pipeline in one clause, and closes with routes LLM calls through dario so deep research runs on your own subscription which ties it to dario without over-narrowing to a single tier.

Row format mirrors dario's row exactly. No other changes.