### PR TITLE
readme: drop Discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@
 
 <div align="center">
 
-**[Discord](https://discord.gg/fENVZpdYcX)** · **[@ask_alf](https://x.com/ask_alf)**
+**[@ask_alf](https://x.com/ask_alf)**
 
 </div>


### PR DESCRIPTION
Removes the Discord link from the README footer, leaving just the @ask_alf link.