### PR TITLE
readme: add claude-bridge row

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 |---------|-------------|---|
 | **[dario](https://github.com/askalf/dario)** | A universal LLM router. One local endpoint, every provider — OpenAI, Groq, OpenRouter, Ollama, Claude subscriptions, any OpenAI-compat URL. Your tools point here and stop caring which vendor is upstream. | [![npm](https://img.shields.io/npm/v/@askalf/dario?label=&color=00ff88&style=flat-square)](https://www.npmjs.com/package/@askalf/dario) |
 | **[deepdive](https://github.com/askalf/deepdive)** | A local research agent. One command, cited answer — plan, search, read, iterate with a critic loop, synthesize. Routes LLM calls through dario so deep research runs on your own subscription. | [![npm](https://img.shields.io/npm/v/@askalf/deepdive?label=&color=00ff88&style=flat-square)](https://www.npmjs.com/package/@askalf/deepdive) |
+| **[claude-bridge](https://github.com/askalf/claude-bridge)** | A Claude Code ↔ Discord bridge. Mirrors your CC sessions to a Discord channel, pings you when Claude goes idle, and runs a full agent loop (Bash / Read / Write / Glob / Grep) on your replies via dario — full remote control from your phone. | [![source](https://img.shields.io/badge/source-github-00ff88?style=flat-square&logo=github)](https://github.com/askalf/claude-bridge) |
 
 ---
 


### PR DESCRIPTION
Adds a claude-bridge row to the askalf/askalf README table, after deepdive. Same copy as the org profile PR — names mechanism + ties it to dario. GitHub source badge since it's source-only for now.