### PR TITLE
Link the now-public amnesia repo from the profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ I'm **Thomas Sprayberry** — 20 years of engineering, from solo founders to For
 
 These aren't demos — **[dario](https://github.com/askalf/dario)** has **200+ stars** and ships on npm, and the studio runs on this stack every day.
 
-**Shipped with it:** **[amnesia.tax](https://amnesia.tax)** — a privacy-first metasearch engine. 155 engines at once, zero tracking, no AI, VPN-tunneled. *Search the web, remember nothing.*
+**Shipped with it:** **[amnesia](https://github.com/askalf/amnesia)** — a privacy-first metasearch engine, live at **[amnesia.tax](https://amnesia.tax)**. 155 engines at once, zero tracking, no AI, VPN-tunneled. *Search the web, remember nothing.*
 
 ---
 


### PR DESCRIPTION
amnesia just went public. The README already features amnesia.tax as a 'Shipped with it' proof point, but only linked the live site - this links the open-source repo too so it's discoverable/star-able.