### PR TITLE
readme: two banners — Own Your Agent Security and Own Your Stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,34 @@
 ![Own Your Stack](banner.png)
 
-# Own Your Stack
+Two banners fly here. **Own Your Agent Security** — govern what your agents are allowed to *do*. **Own Your Stack** — own the AI infrastructure they run on instead of renting it by the token. Related, but not the same question — and each gets its own answer.
 
-**Own your agent security — don't trust agents by default.** A firewall for every agent tool call, a supply-chain gate for every skill, leases instead of raw keys — one layered defense, running in production here.
+## Own Your Agent Security
 
-**And own the rest of your AI infrastructure instead of renting it by the token.** One subscription. Your box. Your terms.
-
-You were sold a meter — intelligence rented by the token, your data through someone else's pipes, your tools on someone else's roadmap and someone else's pricing meeting. I'm building the opposite: a stack you actually *own*. The open tools are the door; a real autonomous studio running in production is the proof — the unfinished parts included.
-
-## The stack
+**Don't trust agents by default.** A firewall for every agent tool call, a supply-chain gate for every skill, leases instead of raw keys, a governed browser between the agent and the open web — one layered defense, running in production here.
 
 | | | |
 |---|---|---|
 | **[warden](https://github.com/askalf/warden)** | **own your agent security** — a firewall for every agent tool call: blocks RCE, secret-exfil, SSRF, and prompt-injection / poisoned MCP tools, with a tamper-evident audit | [![stars](https://img.shields.io/github/stars/askalf/warden?logo=github&label=&color=8b5cf6&style=flat-square)](https://github.com/askalf/warden) |
 | **[canon](https://github.com/askalf/canon)** | **own your agent skills** — vet, sign & pin every skill & MCP server before it runs; drift detection catches a poisoned or silently-updated tool before it ever loads | [![stars](https://img.shields.io/github/stars/askalf/canon?logo=github&label=&color=8b5cf6&style=flat-square)](https://github.com/askalf/canon) |
 | **[keeper](https://github.com/askalf/keeper)** | **own your agent secrets** — an encrypted vault that hands agents scoped, short-lived, single-use leases instead of raw keys; the key never enters the agent's context, and every access is audited | [![stars](https://img.shields.io/github/stars/askalf/keeper?logo=github&label=&color=8b5cf6&style=flat-square)](https://github.com/askalf/keeper) |
+| **[picket](https://github.com/askalf/picket)** | **own your agent browser** — a governed browser for agents: an indirect-prompt-injection firewall, an action gate, and an LLM judge between the agent and the open web, so a hostile page can't hijack the session | [![stars](https://img.shields.io/github/stars/askalf/picket?logo=github&label=&color=8b5cf6&style=flat-square)](https://github.com/askalf/picket) |
+
+> **warden · canon · keeper** compose into one layered defense → **[agent-security-stack](https://github.com/askalf/agent-security-stack)** — vet the tool, contain the call, give it a key it never holds.
+
+## Own Your Stack
+
+**One subscription. Your box. Your terms.** You were sold a meter — intelligence rented by the token, your data through someone else's pipes, your tools on someone else's roadmap and someone else's pricing meeting. I'm building the opposite: a stack you actually *own*. The open tools are the door; a real autonomous studio running in production is the proof — the unfinished parts included.
+
+| | | |
+|---|---|---|
 | **[dario](https://github.com/askalf/dario)** | **own your routing** — your Claude subscription in any tool (Cursor, Cline, Aider, the Agent SDK), at subscription pricing, not per-token bills | [![npm](https://img.shields.io/npm/v/@askalf/dario?logo=npm&logoColor=white&label=&color=8b5cf6&style=flat-square)](https://www.npmjs.com/package/@askalf/dario) |
 | **[hybrid](https://github.com/askalf/hybrid)** | **own your inference** — local-first LLM routing: answer the easy majority on a small local model, escalate only the genuinely hard queries to the frontier; nothing paid or sent off your machine for the rest | [![stars](https://img.shields.io/github/stars/askalf/hybrid?logo=github&label=&color=8b5cf6&style=flat-square)](https://github.com/askalf/hybrid) |
 | **[deepdive](https://github.com/askalf/deepdive)** | **own your research** — a local agent that plans, searches, reads, and synthesizes a cited answer, through your own router | [![npm](https://img.shields.io/npm/v/@askalf/deepdive?logo=npm&logoColor=white&label=&color=8b5cf6&style=flat-square)](https://www.npmjs.com/package/@askalf/deepdive) |
 | **[hands](https://github.com/askalf/hands)** | **own your computer-use** — your LLM on your own mouse, keyboard, and screen, with an audit log of everything it does | [![npm](https://img.shields.io/npm/v/@askalf/hands?logo=npm&logoColor=white&label=&color=8b5cf6&style=flat-square)](https://www.npmjs.com/package/@askalf/hands) |
 | **[cordon](https://github.com/askalf/cordon)** | **own your prompts** — a PII-redacting gateway that fails closed: strip or reversibly tokenize names, emails, and secrets before a prompt ever reaches a model, so your sensitive data never leaves your perimeter | [![stars](https://img.shields.io/github/stars/askalf/cordon?logo=github&label=&color=8b5cf6&style=flat-square)](https://github.com/askalf/cordon) |
-| **[picket](https://github.com/askalf/picket)** | **own your agent browser** — a governed browser for agents: an indirect-prompt-injection firewall, an action gate, and an LLM judge between the agent and the open web, so a hostile page can't hijack the session | [![stars](https://img.shields.io/github/stars/askalf/picket?logo=github&label=&color=8b5cf6&style=flat-square)](https://github.com/askalf/picket) |
 | **[browser-bridge](https://github.com/askalf/browser-bridge)** | **own your browser** — stealth headless Chromium in a container, CDP on your own endpoint | [![ghcr](https://img.shields.io/badge/ghcr-pkg-8b5cf6?style=flat-square)](https://github.com/askalf/browser-bridge/pkgs/container/browser-bridge) |
 | **[amnesia](https://github.com/askalf/amnesia)** | **own your search** — privacy-first metasearch, 155 engines at once, zero tracking, no AI, VPN-tunneled | [![live](https://img.shields.io/badge/live-amnesia.tax-8b5cf6?style=flat-square)](https://amnesia.tax) |
 | **[askalf](https://askalf.org)** | **own your operation** — the self-hosted AI workforce platform the whole stack runs | early access |
-
-> **warden · canon · keeper** compose into one layered defense → **[agent-security-stack](https://github.com/askalf/agent-security-stack)** — vet the tool, contain the call, give it a key it never holds.
 
 More of the stack → **[ownyourstack.sprayberrylabs.com](https://ownyourstack.sprayberrylabs.com)**
 
@@ -52,4 +55,4 @@ Portfolio → **[thomas.sprayberrylabs.com](https://thomas.sprayberrylabs.com)**
 
 ---
 
-**[Own Your Stack](https://ownyourstack.sprayberrylabs.com)** · **[sprayberrylabs.com](https://sprayberrylabs.com)** · **[@ask_alf](https://x.com/ask_alf)** · **hello@sprayberrylabs.com**
+**[Own Your Stack](https://ownyourstack.sprayberrylabs.com)** · **[Own Your Agent Security](https://github.com/askalf/agent-security-stack)** · **[sprayberrylabs.com](https://sprayberrylabs.com)** · **[@ask_alf](https://x.com/ask_alf)** · **hello@sprayberrylabs.com**


### PR DESCRIPTION
Carries the two-banner separation (sprayberrylabs-site #92/#93) onto the profile README, which still told the one-banner story — an "Own Your Stack" h1 with agent security as its opening bullet.

- The h1 is gone (the banner art already carries the wordmark); in its place a one-line intro names both banners and states they are different questions.
- **## Own Your Agent Security** — the "don't trust agents by default" pitch (now including picket's governed browser), a four-row table (warden · canon · keeper · picket), and the trilogy compose-blockquote. Bundle framing untouched: agent-security-stack stays trilogy-only.
- **## Own Your Stack** — the "you were sold a meter" thesis with the remaining tools (dario → askalf). Cordon stays here per the 6/23 decision (standalone tool, not bundle member).
- Footer now links both banners; Own Your Agent Security points at the agent-security-stack repo until it has a dedicated page.

All tool rows, badges, receipts links, and the bio section are carried over verbatim — this is a restructure, not a copy rewrite.

Alongside this PR (direct edits, no PR path): keeper + canon repo descriptions change "Part of Own Your Stack" → "Part of Own Your Agent Security", and the account bio names both banners.
