### PR TITLE
Profile: sweep to the renamed tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Two banners fly here. **Own Your Agent Security** — govern what your agents ar
 
 | | | |
 |---|---|---|
-| **[warden](https://github.com/askalf/warden)** | **own your agent security** — a firewall for every agent tool call: blocks RCE, secret-exfil, SSRF, and prompt-injection / poisoned MCP tools, with a tamper-evident audit | [![stars](https://img.shields.io/github/stars/askalf/warden?logo=github&label=&color=b5372a&style=flat-square)](https://github.com/askalf/warden) |
-| **[canon](https://github.com/askalf/canon)** | **own your agent skills** — vet, sign & pin every skill & MCP server before it runs; drift detection catches a poisoned or silently-updated tool before it ever loads | [![stars](https://img.shields.io/github/stars/askalf/canon?logo=github&label=&color=b5372a&style=flat-square)](https://github.com/askalf/canon) |
-| **[keeper](https://github.com/askalf/keeper)** | **own your agent secrets** — an encrypted vault that hands agents scoped, short-lived, single-use leases instead of raw keys; the key never enters the agent's context, and every access is audited | [![stars](https://img.shields.io/github/stars/askalf/keeper?logo=github&label=&color=b5372a&style=flat-square)](https://github.com/askalf/keeper) |
-| **[picket](https://github.com/askalf/picket)** | **own your agent browser** — a governed browser for agents: an indirect-prompt-injection firewall, an action gate, and an LLM judge between the agent and the open web, so a hostile page can't hijack the session | [![stars](https://img.shields.io/github/stars/askalf/picket?logo=github&label=&color=b5372a&style=flat-square)](https://github.com/askalf/picket) |
+| **[redstamp](https://github.com/askalf/redstamp)** | **own your agent security** — a firewall for every agent tool call: blocks RCE, secret-exfil, SSRF, and prompt-injection / poisoned MCP tools, with a tamper-evident audit | [![stars](https://img.shields.io/github/stars/askalf/redstamp?logo=github&label=&color=b5372a&style=flat-square)](https://github.com/askalf/redstamp) |
+| **[truecopy](https://github.com/askalf/truecopy)** | **own your agent skills** — vet, sign & pin every skill & MCP server before it runs; drift detection catches a poisoned or silently-updated tool before it ever loads | [![stars](https://img.shields.io/github/stars/askalf/truecopy?logo=github&label=&color=b5372a&style=flat-square)](https://github.com/askalf/truecopy) |
+| **[strongroom](https://github.com/askalf/strongroom)** | **own your agent secrets** — an encrypted vault that hands agents scoped, short-lived, single-use leases instead of raw keys; the key never enters the agent's context, and every access is audited | [![stars](https://img.shields.io/github/stars/askalf/strongroom?logo=github&label=&color=b5372a&style=flat-square)](https://github.com/askalf/strongroom) |
+| **[fieldpass](https://github.com/askalf/fieldpass)** | **own your agent browser** — a governed browser for agents: an indirect-prompt-injection firewall, an action gate, and an LLM judge between the agent and the open web, so a hostile page can't hijack the session | [![stars](https://img.shields.io/github/stars/askalf/fieldpass?logo=github&label=&color=b5372a&style=flat-square)](https://github.com/askalf/fieldpass) |
 
-> **warden · canon · keeper** compose into one layered defense → **[agent-security-stack](https://github.com/askalf/agent-security-stack)** — vet the tool, contain the call, give it a key it never holds.
+> **redstamp · truecopy · strongroom** compose into one layered defense → **[agent-security-stack](https://github.com/askalf/agent-security-stack)** — vet the tool, contain the call, give it a key it never holds.
 
 ## Own Your Stack
 
@@ -36,13 +36,13 @@ More of the stack → **[ownyourstack.sprayberrylabs.com](https://ownyourstack.s
 
 [Sprayberry Labs](https://sprayberrylabs.com) is the software studio with one human on staff — and a lab in the literal sense: every claim above traces to a merged PR, a release, or a measured incident. Some of the write-ups:
 
-- **[We scanned the marketplace that started the poisoned-skills panic](https://sprayberrylabs.com/blog/the-marketplace-that-started-the-panic)** — all 66,541 ClawHub skills poison-scanned with canon: zero confirmed malicious, 813 deterministic alarms, every one checked and mapped
-- **[The leaderboard I refused to build](https://sprayberrylabs.com/blog/the-leaderboard-i-refused-to-build)** — why an agent-firewall leaderboard would be a category error; a threat-model map instead, with warden's own benchmark numbers shown, misses included
-- **[Auditing the skills supply chain](https://sprayberrylabs.com/blog/auditing-the-skills-supply-chain)** — canon run across 2,019 published Claude skills: what a real marketplace audit finds, and doesn't
-- **[Zero raw credentials](https://sprayberrylabs.com/blog/keeper-zero-raw-credentials)** — migrating a live agent fleet from 132 inherited environment keys to keeper leases, one seam at a time
-- **[An injection firewall for the agentic browser](https://sprayberrylabs.com/blog/picket-governed-agentic-browser)** — why the lethal trifecta is structural, and how picket gates it
+- **[We scanned the marketplace that started the poisoned-skills panic](https://sprayberrylabs.com/blog/the-marketplace-that-started-the-panic)** — all 66,541 ClawHub skills poison-scanned with truecopy: zero confirmed malicious, 813 deterministic alarms, every one checked and mapped
+- **[The leaderboard I refused to build](https://sprayberrylabs.com/blog/the-leaderboard-i-refused-to-build)** — why an agent-firewall leaderboard would be a category error; a threat-model map instead, with redstamp's own benchmark numbers shown, misses included
+- **[Auditing the skills supply chain](https://sprayberrylabs.com/blog/auditing-the-skills-supply-chain)** — truecopy run across 2,019 published Claude skills: what a real marketplace audit finds, and doesn't
+- **[Zero raw credentials](https://sprayberrylabs.com/blog/keeper-zero-raw-credentials)** — migrating a live agent fleet from 132 inherited environment keys to strongroom leases, one seam at a time
+- **[An injection firewall for the agentic browser](https://sprayberrylabs.com/blog/picket-governed-agentic-browser)** — why the lethal trifecta is structural, and how fieldpass gates it
 - **[A self-healing release pipeline](https://sprayberrylabs.com/blog/dario-self-healing-release-pipeline)** — how dario ships, health-gates, and rolls itself back
-- **Warden governing third-party frameworks** — [CrewAI](https://sprayberrylabs.com/blog/crewai-flowdef-under-askalf) · [LangGraph](https://sprayberrylabs.com/blog/langgraph-under-askalf) · [OpenAI Agents SDK](https://sprayberrylabs.com/blog/openai-agents-under-askalf) · [AutoGen](https://sprayberrylabs.com/blog/autogen-under-askalf), each with a runnable public example in [askalf/warden](https://github.com/askalf/warden/tree/master/examples)
+- **Redstamp governing third-party frameworks** — [CrewAI](https://sprayberrylabs.com/blog/crewai-flowdef-under-askalf) · [LangGraph](https://sprayberrylabs.com/blog/langgraph-under-askalf) · [OpenAI Agents SDK](https://sprayberrylabs.com/blog/openai-agents-under-askalf) · [AutoGen](https://sprayberrylabs.com/blog/autogen-under-askalf), each with a runnable public example in [askalf/redstamp](https://github.com/askalf/redstamp/tree/master/examples)
 
 Full engineering log → **[sprayberrylabs.com/blog](https://sprayberrylabs.com/blog)**
 


### PR DESCRIPTION
Applies the 7/10 rename: table rows, links, and the trilogy blurb. Own Your Agent Security stays as the banner brand; only tool names/links changed.