### PR TITLE
Receipts: dario OpenSSF Scorecard 9.2 -> 9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ More of the stack → **[ownyourstack.sprayberrylabs.com](https://ownyourstack.s
 
 ## The receipts
 
-[Sprayberry Labs](https://sprayberrylabs.com) is the software studio with one human on staff — and a lab in the literal sense: every claim above traces to a merged PR, a release, or a measured incident. The supply chain is scored in public, too: dario holds a [9.2/10 OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/askalf/dario) and a [100% OpenSSF Best Practices badge](https://www.bestpractices.dev/projects/13638) — releases signed and SLSA-attested, npm published tokenless from CI. Some of the write-ups:
+[Sprayberry Labs](https://sprayberrylabs.com) is the software studio with one human on staff — and a lab in the literal sense: every claim above traces to a merged PR, a release, or a measured incident. The supply chain is scored in public, too: dario holds a [9.4/10 OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/askalf/dario) and a [100% OpenSSF Best Practices badge](https://www.bestpractices.dev/projects/13638) — releases signed and SLSA-attested, npm published tokenless from CI. Some of the write-ups:
 
 - **[We scanned the marketplace that started the poisoned-skills panic](https://sprayberrylabs.com/blog/the-marketplace-that-started-the-panic)** — all 66,541 ClawHub skills poison-scanned with truecopy: zero confirmed malicious, 813 deterministic alarms, every one checked and mapped
 - **[The leaderboard I refused to build](https://sprayberrylabs.com/blog/the-leaderboard-i-refused-to-build)** — why an agent-firewall leaderboard would be a category error; a threat-model map instead, with redstamp's own benchmark numbers shown, misses included


### PR DESCRIPTION
dario's live Scorecard rose 9.2 -> 9.4 (api.scorecard.dev, verified 2026-07-20T14:57Z, scorecard v5.3.0). Single-line README bump in the receipts paragraph; no other changes.
